### PR TITLE
Use apply instead of relying on the datasource invoke

### DIFF
--- a/nodejs/azure-serverless/util.ts
+++ b/nodejs/azure-serverless/util.ts
@@ -27,9 +27,9 @@ export function signedBlobReadUrl(
     const signatureStart = new Date(0);
     const signatureExpiration = new Date(2100, 1);
 
-    return blob.url.apply(async (blobUrl) => {
+    return pulumi.all([blob.url, account.primaryConnectionString]).apply(async ([blobUrl, connectionString]) => {
         const accountSAS = await azure.storage.getAccountSAS({
-            connectionString: account.primaryConnectionString,
+            connectionString: connectionString,
             start: signatureStart.toISOString(),
             expiry: signatureExpiration.toISOString(),
             permissions: {


### PR DESCRIPTION
In anticipation of updating to a newer pulumi-azure where datasources
no longer accept Output<T>'s, move to using apply ourselves.